### PR TITLE
docker/build-push-action を v4 に更新

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -49,7 +49,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Build and push to GHCR
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ./Dockerfile
@@ -57,7 +57,7 @@ jobs:
           tags: ${{ steps.meta-ghcr.outputs.tags }}
 
       - name: Build and push to DockerHub
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
`provenance: false` がデフォルトになった